### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -310,7 +310,10 @@ def index():
 def view_notebook(path):
     """Display notebook as HTML with run buttons"""
     repo_dir = os.path.join(os.getcwd(), 'notebooks_repo')
-    notebook_path = os.path.join(repo_dir, path)
+    notebook_path = os.path.normpath(os.path.join(repo_dir, path))
+
+    if not notebook_path.startswith(repo_dir):
+        return "Invalid notebook path", 400
 
     if not os.path.exists(notebook_path):
         return "Notebook not found", 404


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/5](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/5)

To fix the problem, we need to validate the `path` parameter to ensure it does not allow directory traversal. We can achieve this by normalizing the path and ensuring it remains within the intended directory. Specifically, we will:
1. Normalize the `notebook_path` using `os.path.normpath`.
2. Check that the normalized path starts with the `repo_dir` to ensure it does not escape the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
