### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from flask_babel import Babel, gettext as _, lazy_gettext as _l
 from functools import wraps
 from flask import abort
+from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
@@ -129,7 +130,11 @@ REPO_URL = 'https://github.com/msy-bilecik/ist204_2025'
 
 @app.route('/js/component/<filename>')
 def serve_component(filename):
-    file_path = os.path.join(app.template_folder, 'js', 'components', filename)
+    base_path = os.path.join(app.template_folder, 'js', 'components')
+    safe_filename = secure_filename(filename)
+    file_path = os.path.normpath(os.path.join(base_path, safe_filename))
+    if not file_path.startswith(base_path):
+        abort(403)
     with open(file_path, 'r') as file:
         content = file.read()
     return content, 200, {'Content-Type': 'text/javascript'}


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/3](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/3)

To fix the problem, we need to validate the `filename` parameter to ensure it does not contain any malicious input that could lead to path traversal attacks. We can achieve this by normalizing the path and ensuring it remains within the intended directory. Additionally, we can use the `werkzeug.utils.secure_filename` function to sanitize the filename.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Normalize the constructed file path using `os.path.normpath`.
3. Ensure the normalized path starts with the intended base directory.
