### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -583,7 +583,8 @@ def server_status():
         mysql_result = db.session.execute(mysql_version_query).first()
         mysql_version = mysql_result.version if mysql_result else "Unknown"
     except Exception as e:
-        mysql_version = f"Error: {str(e)}"
+        app.logger.error(f"Error fetching MySQL version: {str(e)}")
+        mysql_version = "Error: Unable to fetch MySQL version"
 
     # Get system RAM usage
     mem = psutil.virtual_memory()


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/7](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/7)

To fix the problem, we should avoid exposing detailed error messages to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

1. Import the `logging` module to log the error messages.
2. Replace the line that sets `mysql_version` with the error message to log the error and set a generic error message instead.
