### PR TITLE
Potential fix for code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import nbformat
 import subprocess
 import sys
 import io
+from urllib.parse import urlparse
 import builtins
 from datetime import datetime
 from flask_babel import Babel, gettext as _, lazy_gettext as _l
@@ -367,8 +368,11 @@ def login():
 
         if user and user.check_password(password):
             login_user(user)
-            next_page = request.args.get('next')
-            return redirect(next_page or url_for('index'))
+            next_page = request.args.get('next', '')
+            next_page = next_page.replace('\\', '')
+            if not urlparse(next_page).netloc and not urlparse(next_page).scheme:
+                return redirect(next_page or url_for('index'))
+            return redirect(url_for('index'))
         else:
             flash(_('invalid_login'))
 


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/2](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/2)

To fix the problem, we need to validate the `next_page` parameter before using it in the redirect function. We can use a whitelist of allowed URLs or ensure that the URL is relative and does not contain an explicit host name. This will prevent open redirect vulnerabilities.

The best way to fix the problem without changing existing functionality is to use the `urlparse` function from the Python standard library to check that the `next_page` URL does not specify an explicit host name. If it does, we will ignore the `next_page` and redirect to the home page instead.
