### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,9 +17,11 @@ from flask_babel import Babel, gettext as _, lazy_gettext as _l
 from functools import wraps
 from flask import abort
 from werkzeug.utils import secure_filename
+import logging
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
+logging.basicConfig(level=logging.ERROR)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://radome:12345@localhost/python_platform'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 # Initialize Babel
@@ -335,7 +337,8 @@ def view_notebook(path):
                                notebook=notebook,
                                notebook_path=path)
     except Exception as e:
-        return f"Error loading notebook: {str(e)}", 500
+        logging.error(f"Error loading notebook: {str(e)}")
+        return "An internal error has occurred while loading the notebook.", 500
 
 
 @app.route('/run_code', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/6](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/6)

To fix the problem, we need to ensure that detailed error information is not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using a logging mechanism to record the exception details and modifying the return statement to provide a generic error message.

1. Import the `logging` module to enable logging of error messages.
2. Replace the return statement in the exception block to log the detailed error message and return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
