### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,11 @@ def set_language(lang):
     if lang in app.config['BABEL_SUPPORTED_LOCALES']:
         session.permanent = True  # Make session permanent
         session['language'] = lang
-    return redirect(request.referrer or url_for('index'))
+    referrer = request.referrer or url_for('index')
+    referrer = referrer.replace('\\', '')
+    if not urlparse(referrer).netloc and not urlparse(referrer).scheme:
+        return redirect(referrer, code=302)
+    return redirect(url_for('index'), code=302)
 
 # Role model definitions
 class Role(db.Model):


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/1](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/1)

To fix the problem, we need to validate the `request.referrer` value before using it in the redirect. One way to do this is to ensure that the referrer URL does not contain an explicit host name, making it a relative URL. This can be achieved using the `urlparse` function from the Python standard library. If the referrer URL is not valid, we should redirect to a safe default URL, such as the home page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
