### PR TITLE
Potential fix for code scanning alert no. 890: URL redirection from remote source

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request
+from urllib.parse import urlparse
 from flask_login import login_user, logout_user, current_user
 from app.models.base import db
 from app.models.user import User
@@ -17,8 +18,12 @@ def login():
         user = User.query.filter_by(username=form.username.data).first()
         if user and user.check_password(form.password.data):
             login_user(user, remember=form.remember_me.data)
-            next_page = request.args.get('next')
-            return redirect(next_page or url_for('main.index'))
+            next_page = request.args.get('next', '')
+            from urllib.parse import urlparse
+            next_page = next_page.replace('\\', '')
+            if next_page and not urlparse(next_page).netloc and not urlparse(next_page).scheme:
+                return redirect(next_page)
+            return redirect(url_for('main.index'))
         flash('Geçersiz kullanıcı adı veya şifre')
 
     return render_template('login.html', form=form)


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/890](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/890)

To fix the problem, we need to validate the `next_page` parameter to ensure it does not contain an explicit host name, which could lead to an open redirect vulnerability. We can use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty. This ensures that only relative paths are allowed for redirection.

We will modify the code in the `login` function to include this validation step. Specifically, we will replace the line that directly uses `next_page` in the redirect with a block of code that validates `next_page` first.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
