### PR TITLE
Potential fix for code scanning alert no. 893: Information exposure through an exception

### DIFF
--- a/app/services/notebook_service.py
+++ b/app/services/notebook_service.py
@@ -101,7 +101,8 @@ class NotebookService:
             else:
                 return {'success': False, 'error': stderr}
         except Exception as e:
-            return {'success': False, 'error': str(e)}
+            current_app.logger.error(f"Error running code: {str(e)}")
+            return {'success': False, 'error': 'An internal error has occurred.'}
 
     def handle_socket_run_code(self, code, user_id, socketio=None):
         """Socket.IO ile kodu çalıştır ve çıktıyı Socket.IO kullanarak gönder"""


### PR DESCRIPTION
Potential fix for [https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/893](https://github.com/BatuhanAcikgoz/PythonPlayground/security/code-scanning/893)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the `run_code` method in `NotebookService` to log the exception details and return a generic error message. Additionally, we need to update the `run` route in `notebook.py` to handle the modified response format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
